### PR TITLE
docs: fix incorrect clone commands in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This application provides a web-based interface for voice input, which is then t
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/transcribe-test.git
-   cd transcribe-test
+   git clone git@github.com:Chris-wa-He/AWS-Transcribe-Bedrock.git
+   cd AWS-Transcribe-Bedrock
    ```
 
 2. Install Poetry if you haven't already:
@@ -81,8 +81,8 @@ This application provides a web-based interface for voice input, which is then t
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/transcribe-test.git
-   cd transcribe-test
+   git clone git@github.com:Chris-wa-He/AWS-Transcribe-Bedrock.git
+   cd AWS-Transcribe-Bedrock
    ```
 
 2. Install the required dependencies:

--- a/README.zh.md
+++ b/README.zh.md
@@ -32,8 +32,8 @@
 
 1. 克隆此仓库：
    ```bash
-   git clone https://github.com/yourusername/transcribe-test.git
-   cd transcribe-test
+   git clone git@github.com:Chris-wa-He/AWS-Transcribe-Bedrock.git
+   cd AWS-Transcribe-Bedrock
    ```
 
 2. 如果尚未安装 Poetry，请先安装：
@@ -57,8 +57,8 @@
 
 1. 克隆此仓库：
    ```bash
-   git clone https://github.com/yourusername/transcribe-test.git
-   cd transcribe-test
+   git clone git@github.com:Chris-wa-He/AWS-Transcribe-Bedrock.git
+   cd AWS-Transcribe-Bedrock
    ```
 
 2. 安装所需依赖：


### PR DESCRIPTION
- Replace placeholder URL 'yourusername/transcribe-test' with correct 'Chris-wa-He/AWS-Transcribe-Bedrock'
- Update directory name from 'transcribe-test' to 'AWS-Transcribe-Bedrock'
- Fix clone commands in both English (README.md) and Chinese (README.zh.md) versions
- Ensure consistency between documentation and actual repository structure

Fixes new user onboarding issues where clone commands would fail